### PR TITLE
Dev 8.0

### DIFF
--- a/Apps/CoreTestOne/CoreTestOne.csproj
+++ b/Apps/CoreTestOne/CoreTestOne.csproj
@@ -6,10 +6,10 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Core 8 Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/CoreTestOne/CoreTestOne.csproj
+++ b/Apps/CoreTestOne/CoreTestOne.csproj
@@ -6,10 +6,10 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Core 8 Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/CoreTestOne/CoreTestOne.csproj
+++ b/Apps/CoreTestOne/CoreTestOne.csproj
@@ -6,10 +6,10 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Core 8 Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/SysInfoTool/SysInfoTool.csproj
+++ b/Apps/SysInfoTool/SysInfoTool.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Sample Program</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -17,7 +17,7 @@
     <Platforms>AnyCPU;x64;x86</Platforms>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/SysInfoTool/SysInfoTool.csproj
+++ b/Apps/SysInfoTool/SysInfoTool.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Sample Program</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -17,7 +17,7 @@
     <Platforms>AnyCPU;x64;x86</Platforms>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/SysInfoTool/SysInfoTool.csproj
+++ b/Apps/SysInfoTool/SysInfoTool.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Sample Program</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -17,7 +17,7 @@
     <Platforms>AnyCPU;x64;x86</Platforms>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestDisks/TestDisks.csproj
+++ b/Apps/TestDisks/TestDisks.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Disk Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -17,7 +17,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestDisks/TestDisks.csproj
+++ b/Apps/TestDisks/TestDisks.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Disk Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -17,7 +17,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestDisks/TestDisks.csproj
+++ b/Apps/TestDisks/TestDisks.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Disk Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -17,7 +17,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestExtras/TestExtras.csproj
+++ b/Apps/TestExtras/TestExtras.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Extras Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestExtras/TestExtras.csproj
+++ b/Apps/TestExtras/TestExtras.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Extras Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestExtras/TestExtras.csproj
+++ b/Apps/TestExtras/TestExtras.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Extras Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestHid/TestHid.csproj
+++ b/Apps/TestHid/TestHid.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools HID Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestHid/TestHid.csproj
+++ b/Apps/TestHid/TestHid.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools HID Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestHid/TestHid.csproj
+++ b/Apps/TestHid/TestHid.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools HID Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestNetwork/TestNetwork.csproj
+++ b/Apps/TestNetwork/TestNetwork.csproj
@@ -6,10 +6,10 @@
     <nullable>disable</nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Network Adapters Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestNetwork/TestNetwork.csproj
+++ b/Apps/TestNetwork/TestNetwork.csproj
@@ -6,10 +6,10 @@
     <nullable>disable</nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Network Adapters Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Apps/TestNetwork/TestNetwork.csproj
+++ b/Apps/TestNetwork/TestNetwork.csproj
@@ -6,10 +6,10 @@
     <nullable>disable</nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Network Adapters Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Console/DataTools.Console.csproj
+++ b/Core/DataTools.Console/DataTools.Console.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Color Console</Product>
     <Description>DataTools Color Console</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Console/DataTools.Console.csproj
+++ b/Core/DataTools.Console/DataTools.Console.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
+    <FileVersion>8.0.0.1030</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1030</Version>
     <Product>DataTools Color Console</Product>
     <Description>DataTools Color Console</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1029</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Console/DataTools.Console.csproj
+++ b/Core/DataTools.Console/DataTools.Console.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Color Console</Product>
     <Description>DataTools Color Console</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Essentials/DataTools.Essentials.csproj
+++ b/Core/DataTools.Essentials/DataTools.Essentials.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1033</AssemblyVersion>
-    <FileVersion>8.0.0.1033</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1033</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools App Essentials</Product>
     <Description>DataTools App Essentials</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1032</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Essentials/DataTools.Essentials.csproj
+++ b/Core/DataTools.Essentials/DataTools.Essentials.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1031</AssemblyVersion>
-    <FileVersion>8.0.0.1031</FileVersion>
+    <AssemblyVersion>8.0.0.1033</AssemblyVersion>
+    <FileVersion>8.0.0.1033</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1031</Version>
+    <Version>8.0.0.1033</Version>
     <Product>DataTools App Essentials</Product>
     <Description>DataTools App Essentials</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1030</PreviousVersion>
+    <PreviousVersion>8.0.0.1032</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Essentials/DataTools.Essentials.csproj
+++ b/Core/DataTools.Essentials/DataTools.Essentials.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1031</AssemblyVersion>
+    <FileVersion>8.0.0.1031</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1031</Version>
     <Product>DataTools App Essentials</Product>
     <Description>DataTools App Essentials</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1030</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Essentials/SortedLists/BinarySearch.cs
+++ b/Core/DataTools.Essentials/SortedLists/BinarySearch.cs
@@ -12,26 +12,29 @@ namespace DataTools.Essentials.SortedLists
         #region Public Methods
 
         /// <summary>
-        /// Perform an assisted tree walk to look for something.
+        /// Perform an assisted binary walk to look for something.
         /// </summary>
         /// <typeparam name="TList">The type of list to search.</typeparam>
         /// <typeparam name="TItem">The type of item to search.</typeparam>
         /// <param name="compare">A function that will take the right-hand object as a parameter and return a comparison integer.</param>
         /// <param name="source">The source list.</param>
         /// <param name="retobj">The optional return object.</param>
-        /// <param name="first">True to return the first match in a list with repeating elements.</param>
+        /// <param name="first">True to return the index of the first match in a list with duplicate keys.</param>
         /// <param name="insertIndex">True to return an insert index instead of -1.<br />
-        /// If set to true, match success must be tested by checking if the <paramref name="retobj"/> parameter contains an object or is null.</param>
+        /// If set to true, match success must be tested by checking if the <paramref name="retobj"/> parameter contains an object or is default.</param>
         /// <returns></returns>
         /// <remarks>
         /// The assumption is made that the caller already has the criteria they are looking for.<br />
-        /// They can implement a lambda or method to compare their data to the object passed into the lambda.
+        /// They can implement a lambda or method to compare their data to the object passed<br /> into the lambda.
         /// <br /><br />
         /// In this use case, the method will be called with the right-hand parameter.<br />
         /// The data the caller has would be treated as the left-hand parameter.
         /// <br /><br />
-        /// If <paramref name="insertIndex"/> is true, an insert index will be returned instead of -1,<br />
-        /// and match success must be tested by checking if the <paramref name="retobj"/> parameter contains an object or is null.
+        /// If <paramref name="insertIndex"/> is true, an insert index will be returned instead of -1, and match<br />
+        /// success must be tested by checking if the <paramref name="retobj"/> parameter contains an object<br />
+        /// or is default.
+        /// <br /><br />
+        /// If <typeparamref name="TItem"/> is a structure or value type, consider using <see cref="Nullable{TItem}"/>, instead.
         /// </remarks>
         public static int Search<TList, TItem>(
            Func<TItem, int> compare,
@@ -39,7 +42,6 @@ namespace DataTools.Essentials.SortedLists
            out TItem retobj,
            bool first = false,
            bool insertIndex = false)
-
            where TList : IList<TItem>
         {
             if (source == null || source.Count == 0)

--- a/Core/DataTools.Essentials/SortedLists/BinarySearch.cs
+++ b/Core/DataTools.Essentials/SortedLists/BinarySearch.cs
@@ -12,6 +12,97 @@ namespace DataTools.Essentials.SortedLists
         #region Public Methods
 
         /// <summary>
+        /// Perform an assisted tree walk to look for something.
+        /// </summary>
+        /// <typeparam name="TList">The type of list to search.</typeparam>
+        /// <typeparam name="TItem">The type of item to search.</typeparam>
+        /// <param name="compare">A function that will take the right-hand object as a parameter and return a comparison integer.</param>
+        /// <param name="source">The source list.</param>
+        /// <param name="retobj">The optional return object.</param>
+        /// <param name="first">True to return the first match in a list with repeating elements.</param>
+        /// <param name="insertIndex">True to return an insert index instead of -1.<br />
+        /// If set to true, match success must be tested by checking if the <paramref name="retobj"/> parameter contains an object or is null.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The assumption is made that the caller already has the criteria they are looking for.<br />
+        /// They can implement a lambda or method to compare their data to the object passed into the lambda.
+        /// <br /><br />
+        /// In this use case, the method will be called with the right-hand parameter.<br />
+        /// The data the caller has would be treated as the left-hand parameter.
+        /// <br /><br />
+        /// If <paramref name="insertIndex"/> is true, an insert index will be returned instead of -1,<br />
+        /// and match success must be tested by checking if the <paramref name="retobj"/> parameter contains an object or is null.
+        /// </remarks>
+        public static int Search<TList, TItem>(
+           Func<TItem, int> compare,
+           TList source,
+           out TItem retobj,
+           bool first = false,
+           bool insertIndex = false)
+
+           where TList : IList<TItem>
+        {
+            if (source == null || source.Count == 0)
+            {
+                retobj = default;
+                return insertIndex ? 0 : -1;
+            }
+
+            int lo = 0, hi = source.Count - 1;
+
+            TItem comp;
+
+            while (true)
+            {
+                if (lo > hi) break;
+
+                int p = (hi + lo) / 2;
+
+                comp = source[p];
+
+                int c = compare(comp);
+                if (c == 0)
+                {
+                    if (first && p > 0)
+                    {
+                        p--;
+
+                        do
+                        {
+                            comp = source[p];
+
+                            c = compare(comp);
+
+                            if (c != 0)
+                            {
+                                break;
+                            }
+
+                            p--;
+                        } while (p >= 0);
+
+                        ++p;
+                        comp = source[p];
+                    }
+
+                    retobj = comp;
+                    return p;
+                }
+                else if (c < 0)
+                {
+                    hi = p - 1;
+                }
+                else
+                {
+                    lo = p + 1;
+                }
+            }
+
+            retobj = default;
+            return insertIndex ? lo : -1;
+        }
+
+        /// <summary>
         /// Sorts an array and find an object in the specified sorted array of objects that implement <see cref="IComparable{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of the object to sort and search.</typeparam>

--- a/Core/DataTools.Graphics/DataTools.Graphics.csproj
+++ b/Core/DataTools.Graphics/DataTools.Graphics.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Graphics Library</Product>
     <Description>DataTools Graphics Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Graphics/DataTools.Graphics.csproj
+++ b/Core/DataTools.Graphics/DataTools.Graphics.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Graphics Library</Product>
     <Description>DataTools Graphics Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Graphics/DataTools.Graphics.csproj
+++ b/Core/DataTools.Graphics/DataTools.Graphics.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Graphics Library</Product>
     <Description>DataTools Graphics Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.MathTools/DataTools.MathTools.csproj
+++ b/Core/DataTools.MathTools/DataTools.MathTools.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1031</AssemblyVersion>
+    <FileVersion>8.0.0.1031</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1031</Version>
     <Product>DataTools Miscellaneous Math Tools</Product>
     <Description>DataTools Miscellaneous Math Tools</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1030</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.MathTools/DataTools.MathTools.csproj
+++ b/Core/DataTools.MathTools/DataTools.MathTools.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1031</AssemblyVersion>
-    <FileVersion>8.0.0.1031</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1031</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Miscellaneous Math Tools</Product>
     <Description>DataTools Miscellaneous Math Tools</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1030</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.MathTools/DataTools.MathTools.csproj
+++ b/Core/DataTools.MathTools/DataTools.MathTools.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
+    <FileVersion>8.0.0.1030</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1030</Version>
     <Product>DataTools Miscellaneous Math Tools</Product>
     <Description>DataTools Miscellaneous Math Tools</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1029</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Memory/DataTools.Memory.csproj
+++ b/Core/DataTools.Memory/DataTools.Memory.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Memory Objects</Product>
     <Description>DataTools Memory Objects</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Memory/DataTools.Memory.csproj
+++ b/Core/DataTools.Memory/DataTools.Memory.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Memory Objects</Product>
     <Description>DataTools Memory Objects</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Memory/DataTools.Memory.csproj
+++ b/Core/DataTools.Memory/DataTools.Memory.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
+    <FileVersion>8.0.0.1030</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1030</Version>
     <Product>DataTools Memory Objects</Product>
     <Description>DataTools Memory Objects</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1029</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Core/DataTools.Text/DataTools.Text.csproj
+++ b/Core/DataTools.Text/DataTools.Text.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1033</AssemblyVersion>
-    <FileVersion>8.0.0.1033</FileVersion>
+    <AssemblyVersion>8.0.0.1034</AssemblyVersion>
+    <FileVersion>8.0.0.1034</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <PreviousVersion>8.0.0.1032</PreviousVersion>
+    <PreviousVersion>8.0.0.1033</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
-    <Version>8.0.0.1033</Version>
+    <Version>8.0.0.1034</Version>
     <Product>DataTools Text Library</Product>
     <Description>DataTools Text Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>

--- a/Core/DataTools.Text/DataTools.Text.csproj
+++ b/Core/DataTools.Text/DataTools.Text.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1034</AssemblyVersion>
-    <FileVersion>8.0.0.1034</FileVersion>
+    <AssemblyVersion>8.0.0.1035</AssemblyVersion>
+    <FileVersion>8.0.0.1035</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <PreviousVersion>8.0.0.1033</PreviousVersion>
+    <PreviousVersion>8.0.0.1034</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
-    <Version>8.0.0.1034</Version>
+    <Version>8.0.0.1035</Version>
     <Product>DataTools Text Library</Product>
     <Description>DataTools Text Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>

--- a/Core/DataTools.Text/DataTools.Text.csproj
+++ b/Core/DataTools.Text/DataTools.Text.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1035</AssemblyVersion>
-    <FileVersion>8.0.0.1035</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <PreviousVersion>8.0.0.1034</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
-    <Version>8.0.0.1035</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Text Library</Product>
     <Description>DataTools Text Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>

--- a/Extras/DataTools.Extras/DataTools.Extras.csproj
+++ b/Extras/DataTools.Extras/DataTools.Extras.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Extras</Product>
     <Description>DataTools Extras</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Extras/DataTools.Extras/DataTools.Extras.csproj
+++ b/Extras/DataTools.Extras/DataTools.Extras.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
+    <FileVersion>8.0.0.1030</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1030</Version>
     <Product>DataTools Extras</Product>
     <Description>DataTools Extras</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1029</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Extras/DataTools.Extras/DataTools.Extras.csproj
+++ b/Extras/DataTools.Extras/DataTools.Extras.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0;net48</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Extras</Product>
     <Description>DataTools Extras</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Extras/DataTools.PluginFramework/DataTools.PluginFramework.csproj
+++ b/Extras/DataTools.PluginFramework/DataTools.PluginFramework.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <LangVersion>preview</LangVersion>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Plugin Framework</Product>
     <Description>DataTools Plugin Framework</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Extras/DataTools.PluginFramework/DataTools.PluginFramework.csproj
+++ b/Extras/DataTools.PluginFramework/DataTools.PluginFramework.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <LangVersion>preview</LangVersion>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Plugin Framework</Product>
     <Description>DataTools Plugin Framework</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Extras/DataTools.PluginFramework/DataTools.PluginFramework.csproj
+++ b/Extras/DataTools.PluginFramework/DataTools.PluginFramework.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <LangVersion>preview</LangVersion>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Plugin Framework</Product>
     <Description>DataTools Plugin Framework</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -18,7 +18,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/MAUI/DataTools.MAUI.ColorControls/DataTools.MAUI.ColorControls.csproj
+++ b/MAUI/DataTools.MAUI.ColorControls/DataTools.MAUI.ColorControls.csproj
@@ -14,17 +14,17 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools MAUI Color Controls</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Platforms\Android\" />

--- a/MAUI/DataTools.MAUI.ColorControls/DataTools.MAUI.ColorControls.csproj
+++ b/MAUI/DataTools.MAUI.ColorControls/DataTools.MAUI.ColorControls.csproj
@@ -14,17 +14,17 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools MAUI Color Controls</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Platforms\Android\" />

--- a/MAUI/DataTools.MAUI.ColorControls/DataTools.MAUI.ColorControls.csproj
+++ b/MAUI/DataTools.MAUI.ColorControls/DataTools.MAUI.ColorControls.csproj
@@ -14,17 +14,17 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools MAUI Color Controls</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Platforms\Android\" />

--- a/MAUI/TouchTracking.MAUI/TouchTracking.MAUI.csproj
+++ b/MAUI/TouchTracking.MAUI/TouchTracking.MAUI.csproj
@@ -13,17 +13,17 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Network Adapters Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Platforms\Android\" />

--- a/MAUI/TouchTracking.MAUI/TouchTracking.MAUI.csproj
+++ b/MAUI/TouchTracking.MAUI/TouchTracking.MAUI.csproj
@@ -13,17 +13,17 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Network Adapters Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Platforms\Android\" />

--- a/MAUI/TouchTracking.MAUI/TouchTracking.MAUI.csproj
+++ b/MAUI/TouchTracking.MAUI/TouchTracking.MAUI.csproj
@@ -13,17 +13,17 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Network Adapters Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Platforms\Android\" />

--- a/Win32/DataTools.Computer/DataTools.Computer.csproj
+++ b/Win32/DataTools.Computer/DataTools.Computer.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
-    <AssemblyVersion>8.0.0.1026</AssemblyVersion>
-    <FileVersion>8.0.0.1026</FileVersion>
+    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
+    <FileVersion>8.0.0.1027</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1026</Version>
+    <Version>8.0.0.1027</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Aggregated Computer-Wide Hardware Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1025</PreviousVersion>
+    <PreviousVersion>8.0.0.1026</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Computer/DataTools.Computer.csproj
+++ b/Win32/DataTools.Computer/DataTools.Computer.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Aggregated Computer-Wide Hardware Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Computer/DataTools.Computer.csproj
+++ b/Win32/DataTools.Computer/DataTools.Computer.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Aggregated Computer-Wide Hardware Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Bluetooth/DataTools.Win32.Bluetooth.csproj
+++ b/Win32/DataTools.Win32.Bluetooth/DataTools.Win32.Bluetooth.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Win32 Bluetooth Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -16,7 +16,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataTools.Win32.Memory\DataTools.Win32.Memory.csproj" />

--- a/Win32/DataTools.Win32.Bluetooth/DataTools.Win32.Bluetooth.csproj
+++ b/Win32/DataTools.Win32.Bluetooth/DataTools.Win32.Bluetooth.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Win32 Bluetooth Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -16,7 +16,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataTools.Win32.Memory\DataTools.Win32.Memory.csproj" />

--- a/Win32/DataTools.Win32.Bluetooth/DataTools.Win32.Bluetooth.csproj
+++ b/Win32/DataTools.Win32.Bluetooth/DataTools.Win32.Bluetooth.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Win32 Bluetooth Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -16,7 +16,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataTools.Win32.Memory\DataTools.Win32.Memory.csproj" />

--- a/Win32/DataTools.Win32.Disk/DataTools.Win32.Disk.csproj
+++ b/Win32/DataTools.Win32.Disk/DataTools.Win32.Disk.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Disk Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -23,7 +23,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Disk/DataTools.Win32.Disk.csproj
+++ b/Win32/DataTools.Win32.Disk/DataTools.Win32.Disk.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
+    <FileVersion>8.0.0.1030</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1030</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Disk Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -23,7 +23,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1029</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Disk/DataTools.Win32.Disk.csproj
+++ b/Win32/DataTools.Win32.Disk/DataTools.Win32.Disk.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Disk Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -23,7 +23,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Display/DataTools.Win32.Display.csproj
+++ b/Win32/DataTools.Win32.Display/DataTools.Win32.Display.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1026</AssemblyVersion>
-    <FileVersion>8.0.0.1026</FileVersion>
+    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
+    <FileVersion>8.0.0.1027</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1026</Version>
+    <Version>8.0.0.1027</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Display Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1025</PreviousVersion>
+    <PreviousVersion>8.0.0.1026</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Display/DataTools.Win32.Display.csproj
+++ b/Win32/DataTools.Win32.Display/DataTools.Win32.Display.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Display Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Display/DataTools.Win32.Display.csproj
+++ b/Win32/DataTools.Win32.Display/DataTools.Win32.Display.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Display Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.FileSystem/DataTools.Win32.FileSystem.csproj
+++ b/Win32/DataTools.Win32.FileSystem/DataTools.Win32.FileSystem.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1026</AssemblyVersion>
-    <FileVersion>8.0.0.1026</FileVersion>
+    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
+    <FileVersion>8.0.0.1027</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1026</Version>
+    <Version>8.0.0.1027</Version>
     <Product>DataTools Win32 File System and Shell Library</Product>
     <Description>DataTools Win32 File System and Shell Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -21,7 +21,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1025</PreviousVersion>
+    <PreviousVersion>8.0.0.1026</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.FileSystem/DataTools.Win32.FileSystem.csproj
+++ b/Win32/DataTools.Win32.FileSystem/DataTools.Win32.FileSystem.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Win32 File System and Shell Library</Product>
     <Description>DataTools Win32 File System and Shell Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -21,7 +21,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.FileSystem/DataTools.Win32.FileSystem.csproj
+++ b/Win32/DataTools.Win32.FileSystem/DataTools.Win32.FileSystem.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Win32 File System and Shell Library</Product>
     <Description>DataTools Win32 File System and Shell Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -21,7 +21,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Memory/DataTools.Win32.Memory.csproj
+++ b/Win32/DataTools.Win32.Memory/DataTools.Win32.Memory.csproj
@@ -4,10 +4,10 @@
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Win32 Core Memory Library</Product>
     <Description>DataTools Win32 Core Memory Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Memory/DataTools.Win32.Memory.csproj
+++ b/Win32/DataTools.Win32.Memory/DataTools.Win32.Memory.csproj
@@ -4,10 +4,10 @@
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Win32 Core Memory Library</Product>
     <Description>DataTools Win32 Core Memory Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Memory/DataTools.Win32.Memory.csproj
+++ b/Win32/DataTools.Win32.Memory/DataTools.Win32.Memory.csproj
@@ -4,10 +4,10 @@
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>preview</LangVersion>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Win32 Core Memory Library</Product>
     <Description>DataTools Win32 Core Memory Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Network/DataTools.Win32.Network.csproj
+++ b/Win32/DataTools.Win32.Network/DataTools.Win32.Network.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Network Adapter Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Network/DataTools.Win32.Network.csproj
+++ b/Win32/DataTools.Win32.Network/DataTools.Win32.Network.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Network Adapter Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Network/DataTools.Win32.Network.csproj
+++ b/Win32/DataTools.Win32.Network/DataTools.Win32.Network.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Network Adapter Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Printers/DataTools.Win32.Printers.csproj
+++ b/Win32/DataTools.Win32.Printers/DataTools.Win32.Printers.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Printer and Print Queue Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Printers/DataTools.Win32.Printers.csproj
+++ b/Win32/DataTools.Win32.Printers/DataTools.Win32.Printers.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
+    <FileVersion>8.0.0.1030</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1030</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Printer and Print Queue Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1029</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Printers/DataTools.Win32.Printers.csproj
+++ b/Win32/DataTools.Win32.Printers/DataTools.Win32.Printers.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Printer and Print Queue Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Processor/DataTools.Win32.Processor.csproj
+++ b/Win32/DataTools.Win32.Processor/DataTools.Win32.Processor.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
+    <FileVersion>8.0.0.1030</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1030</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - CPU Info Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1029</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Processor/DataTools.Win32.Processor.csproj
+++ b/Win32/DataTools.Win32.Processor/DataTools.Win32.Processor.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - CPU Info Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Processor/DataTools.Win32.Processor.csproj
+++ b/Win32/DataTools.Win32.Processor/DataTools.Win32.Processor.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1030</AssemblyVersion>
-    <FileVersion>8.0.0.1030</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1030</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - CPU Info Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1029</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.TrueType/DataTools.Win32.TrueType.csproj
+++ b/Win32/DataTools.Win32.TrueType/DataTools.Win32.TrueType.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Win32 TrueType Font Reader Library</Product>
     <Description>DataTools Win32 TrueType Font Reader Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.TrueType/DataTools.Win32.TrueType.csproj
+++ b/Win32/DataTools.Win32.TrueType/DataTools.Win32.TrueType.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Win32 TrueType Font Reader Library</Product>
     <Description>DataTools Win32 TrueType Font Reader Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.TrueType/DataTools.Win32.TrueType.csproj
+++ b/Win32/DataTools.Win32.TrueType/DataTools.Win32.TrueType.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Win32 TrueType Font Reader Library</Product>
     <Description>DataTools Win32 TrueType Font Reader Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Usb/DataTools.Win32.Usb.csproj
+++ b/Win32/DataTools.Win32.Usb/DataTools.Win32.Usb.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - USB and USB HID Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Usb/DataTools.Win32.Usb.csproj
+++ b/Win32/DataTools.Win32.Usb/DataTools.Win32.Usb.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - USB and USB HID Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32.Usb/DataTools.Win32.Usb.csproj
+++ b/Win32/DataTools.Win32.Usb/DataTools.Win32.Usb.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - USB and USB HID Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32/DataTools.Win32.csproj
+++ b/Win32/DataTools.Win32/DataTools.Win32.csproj
@@ -5,10 +5,10 @@
     <nullable>disable</nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1024</AssemblyVersion>
-    <FileVersion>8.0.0.1024</FileVersion>
+    <AssemblyVersion>8.0.0.1025</AssemblyVersion>
+    <FileVersion>8.0.0.1025</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1024</Version>
+    <Version>8.0.0.1025</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Base Hardware Information Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
     <Title>DataTools.Win32</Title>
-    <PreviousVersion>8.0.0.1023</PreviousVersion>
+    <PreviousVersion>8.0.0.1024</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32/DataTools.Win32.csproj
+++ b/Win32/DataTools.Win32/DataTools.Win32.csproj
@@ -5,10 +5,10 @@
     <nullable>disable</nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1026</AssemblyVersion>
-    <FileVersion>8.0.0.1026</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1026</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Base Hardware Information Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
     <Title>DataTools.Win32</Title>
-    <PreviousVersion>8.0.0.1025</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Win32/DataTools.Win32/DataTools.Win32.csproj
+++ b/Win32/DataTools.Win32/DataTools.Win32.csproj
@@ -5,10 +5,10 @@
     <nullable>disable</nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>DataTools</RootNamespace>
-    <AssemblyVersion>8.0.0.1025</AssemblyVersion>
-    <FileVersion>8.0.0.1025</FileVersion>
+    <AssemblyVersion>8.0.0.1026</AssemblyVersion>
+    <FileVersion>8.0.0.1026</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1025</Version>
+    <Version>8.0.0.1026</Version>
     <Product>DataTools Hardware Library</Product>
     <Description>DataTools Hardware Library - Base Hardware Information Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -20,7 +20,7 @@
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
     <Title>DataTools.Win32</Title>
-    <PreviousVersion>8.0.0.1024</PreviousVersion>
+    <PreviousVersion>8.0.0.1025</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/DataTools.Desktop/DataTools.Desktop.csproj
+++ b/Windows/DataTools.Desktop/DataTools.Desktop.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Desktop Base Library</Product>
     <Description>DataTools Desktop Base Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/DataTools.Desktop/DataTools.Desktop.csproj
+++ b/Windows/DataTools.Desktop/DataTools.Desktop.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Desktop Base Library</Product>
     <Description>DataTools Desktop Base Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/DataTools.Desktop/DataTools.Desktop.csproj
+++ b/Windows/DataTools.Desktop/DataTools.Desktop.csproj
@@ -4,10 +4,10 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <nullable>disable</nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Desktop Base Library</Product>
     <Description>DataTools Desktop Base Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.ColorControls/DataTools.ColorControls.csproj
+++ b/Windows/WPF/DataTools.ColorControls/DataTools.ColorControls.csproj
@@ -5,10 +5,10 @@
     <Nullable>disable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools WPF Color Control Library</Product>
     <Description>DataTools WPF Color Control Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.ColorControls/DataTools.ColorControls.csproj
+++ b/Windows/WPF/DataTools.ColorControls/DataTools.ColorControls.csproj
@@ -5,10 +5,10 @@
     <Nullable>disable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1026</AssemblyVersion>
-    <FileVersion>8.0.0.1026</FileVersion>
+    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
+    <FileVersion>8.0.0.1027</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1026</Version>
+    <Version>8.0.0.1027</Version>
     <Product>DataTools WPF Color Control Library</Product>
     <Description>DataTools WPF Color Control Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1025</PreviousVersion>
+    <PreviousVersion>8.0.0.1026</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.ColorControls/DataTools.ColorControls.csproj
+++ b/Windows/WPF/DataTools.ColorControls/DataTools.ColorControls.csproj
@@ -5,10 +5,10 @@
     <Nullable>disable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools WPF Color Control Library</Product>
     <Description>DataTools WPF Color Control Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -22,7 +22,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.Desktop.Network/DataTools.Desktop.Network.csproj
+++ b/Windows/WPF/DataTools.Desktop.Network/DataTools.Desktop.Network.csproj
@@ -6,10 +6,10 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Desktop Network Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.Desktop.Network/DataTools.Desktop.Network.csproj
+++ b/Windows/WPF/DataTools.Desktop.Network/DataTools.Desktop.Network.csproj
@@ -6,10 +6,10 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Desktop Network Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.Desktop.Network/DataTools.Desktop.Network.csproj
+++ b/Windows/WPF/DataTools.Desktop.Network/DataTools.Desktop.Network.csproj
@@ -6,10 +6,10 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Desktop Network Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -19,7 +19,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.Desktop.WPF/DataTools.Desktop.WPF.csproj
+++ b/Windows/WPF/DataTools.Desktop.WPF/DataTools.Desktop.WPF.csproj
@@ -6,10 +6,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
-    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
-    <FileVersion>8.0.0.1029</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1029</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Desktop WPF Base Library</Product>
     <Description>DataTools Desktop WPF Base Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -24,7 +24,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1028</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.Desktop.WPF/DataTools.Desktop.WPF.csproj
+++ b/Windows/WPF/DataTools.Desktop.WPF/DataTools.Desktop.WPF.csproj
@@ -6,10 +6,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
-    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
-    <FileVersion>8.0.0.1028</FileVersion>
+    <AssemblyVersion>8.0.0.1029</AssemblyVersion>
+    <FileVersion>8.0.0.1029</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1028</Version>
+    <Version>8.0.0.1029</Version>
     <Product>DataTools Desktop WPF Base Library</Product>
     <Description>DataTools Desktop WPF Base Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -24,7 +24,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1027</PreviousVersion>
+    <PreviousVersion>8.0.0.1028</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WPF/DataTools.Desktop.WPF/DataTools.Desktop.WPF.csproj
+++ b/Windows/WPF/DataTools.Desktop.WPF/DataTools.Desktop.WPF.csproj
@@ -6,10 +6,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
-    <AssemblyVersion>8.0.0.1027</AssemblyVersion>
-    <FileVersion>8.0.0.1027</FileVersion>
+    <AssemblyVersion>8.0.0.1028</AssemblyVersion>
+    <FileVersion>8.0.0.1028</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1027</Version>
+    <Version>8.0.0.1028</Version>
     <Product>DataTools Desktop WPF Base Library</Product>
     <Description>DataTools Desktop WPF Base Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
@@ -24,7 +24,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Configurations>Debug;Release;NuGet</Configurations>
     <Nullable>disable</Nullable>
-    <PreviousVersion>8.0.0.1026</PreviousVersion>
+    <PreviousVersion>8.0.0.1027</PreviousVersion>
     <AssemblyOriginatorKeyFile>E:\Projects\Keys\datatools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>

--- a/Windows/WinUI/DataTools.WinUI.ColorControls/DataTools.WinUI.ColorControls.csproj
+++ b/Windows/WinUI/DataTools.WinUI.ColorControls/DataTools.WinUI.ColorControls.csproj
@@ -5,10 +5,10 @@
     <RootNamespace>DataTools.WinUI.ColorControls</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools WinUI Color Controls Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2022 Nathaniel Moschkin</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Windows/WinUI/DataTools.WinUI.ColorControls/DataTools.WinUI.ColorControls.csproj
+++ b/Windows/WinUI/DataTools.WinUI.ColorControls/DataTools.WinUI.ColorControls.csproj
@@ -5,10 +5,10 @@
     <RootNamespace>DataTools.WinUI.ColorControls</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools WinUI Color Controls Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2022 Nathaniel Moschkin</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Windows/WinUI/DataTools.WinUI.ColorControls/DataTools.WinUI.ColorControls.csproj
+++ b/Windows/WinUI/DataTools.WinUI.ColorControls/DataTools.WinUI.ColorControls.csproj
@@ -5,10 +5,10 @@
     <RootNamespace>DataTools.WinUI.ColorControls</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools WinUI Color Controls Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2022 Nathaniel Moschkin</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Windows/WinUI/DataTools.WinUI/DataTools.WinUI.csproj
+++ b/Windows/WinUI/DataTools.WinUI/DataTools.WinUI.csproj
@@ -8,17 +8,17 @@
     <LangVersion>preview</LangVersion>
     <Platforms>AnyCPU;x64</Platforms>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools WinUI Base Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2022 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.12" />

--- a/Windows/WinUI/DataTools.WinUI/DataTools.WinUI.csproj
+++ b/Windows/WinUI/DataTools.WinUI/DataTools.WinUI.csproj
@@ -8,17 +8,17 @@
     <LangVersion>preview</LangVersion>
     <Platforms>AnyCPU;x64</Platforms>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools WinUI Base Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2022 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.12" />

--- a/Windows/WinUI/DataTools.WinUI/DataTools.WinUI.csproj
+++ b/Windows/WinUI/DataTools.WinUI/DataTools.WinUI.csproj
@@ -8,17 +8,17 @@
     <LangVersion>preview</LangVersion>
     <Platforms>AnyCPU;x64</Platforms>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools WinUI Base Library</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2022 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.12" />

--- a/Xamarin/DataTools.XamarinForms.ColorControls/DataTools.XamarinForms.ColorControls.csproj
+++ b/Xamarin/DataTools.XamarinForms.ColorControls/DataTools.XamarinForms.ColorControls.csproj
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Xamarin.Forms Color Controls Library</Product>
     <Description>DataTools Xamarin.Forms Color Controls Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Xamarin/DataTools.XamarinForms.ColorControls/DataTools.XamarinForms.ColorControls.csproj
+++ b/Xamarin/DataTools.XamarinForms.ColorControls/DataTools.XamarinForms.ColorControls.csproj
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Xamarin.Forms Color Controls Library</Product>
     <Description>DataTools Xamarin.Forms Color Controls Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Xamarin/DataTools.XamarinForms.ColorControls/DataTools.XamarinForms.ColorControls.csproj
+++ b/Xamarin/DataTools.XamarinForms.ColorControls/DataTools.XamarinForms.ColorControls.csproj
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Xamarin.Forms Color Controls Library</Product>
     <Description>DataTools Xamarin.Forms Color Controls Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Xamarin/XamCtlTest/XamCtlTest.Android/XamCtlTest.Android.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest.Android/XamCtlTest.Android.csproj
@@ -21,10 +21,10 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
-    <Version>8.0.0.1022</Version>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <Version>8.0.0.1023</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin/XamCtlTest/XamCtlTest.Android/XamCtlTest.Android.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest.Android/XamCtlTest.Android.csproj
@@ -21,10 +21,10 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
-    <Version>8.0.0.1021</Version>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <Version>8.0.0.1022</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin/XamCtlTest/XamCtlTest.Android/XamCtlTest.Android.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest.Android/XamCtlTest.Android.csproj
@@ -21,10 +21,10 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp></NuGetPackageImportStamp>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
-    <Version>8.0.0.1023</Version>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
+    <Version>8.0.0.1037</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin/XamCtlTest/XamCtlTest.iOS/XamCtlTest.iOS.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest.iOS/XamCtlTest.iOS.csproj
@@ -14,10 +14,10 @@
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <ProvisioningType>automatic</ProvisioningType>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
-    <Version>8.0.0.1021</Version>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <Version>8.0.0.1022</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin/XamCtlTest/XamCtlTest.iOS/XamCtlTest.iOS.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest.iOS/XamCtlTest.iOS.csproj
@@ -14,10 +14,10 @@
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <ProvisioningType>automatic</ProvisioningType>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
-    <Version>8.0.0.1022</Version>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <Version>8.0.0.1023</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin/XamCtlTest/XamCtlTest.iOS/XamCtlTest.iOS.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest.iOS/XamCtlTest.iOS.csproj
@@ -14,10 +14,10 @@
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <ProvisioningType>automatic</ProvisioningType>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
-    <Version>8.0.0.1023</Version>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
+    <Version>8.0.0.1037</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin/XamCtlTest/XamCtlTest/XamCtlTest.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest/XamCtlTest.csproj
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <AssemblyVersion>8.0.0.1021</AssemblyVersion>
-    <FileVersion>8.0.0.1021</FileVersion>
+    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
+    <FileVersion>8.0.0.1022</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1021</Version>
+    <Version>8.0.0.1022</Version>
     <Product>DataTools Xamarin Controls Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1020</PreviousVersion>
+    <PreviousVersion>8.0.0.1021</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TouchTracking.Forms" Version="1.1.0" />

--- a/Xamarin/XamCtlTest/XamCtlTest/XamCtlTest.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest/XamCtlTest.csproj
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <AssemblyVersion>8.0.0.1022</AssemblyVersion>
-    <FileVersion>8.0.0.1022</FileVersion>
+    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
+    <FileVersion>8.0.0.1023</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1022</Version>
+    <Version>8.0.0.1023</Version>
     <Product>DataTools Xamarin Controls Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1021</PreviousVersion>
+    <PreviousVersion>8.0.0.1022</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TouchTracking.Forms" Version="1.1.0" />

--- a/Xamarin/XamCtlTest/XamCtlTest/XamCtlTest.csproj
+++ b/Xamarin/XamCtlTest/XamCtlTest/XamCtlTest.csproj
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <AssemblyVersion>8.0.0.1023</AssemblyVersion>
-    <FileVersion>8.0.0.1023</FileVersion>
+    <AssemblyVersion>8.0.0.1037</AssemblyVersion>
+    <FileVersion>8.0.0.1037</FileVersion>
     <Authors>Nathaniel Moschkin</Authors>
-    <Version>8.0.0.1023</Version>
+    <Version>8.0.0.1037</Version>
     <Product>DataTools Xamarin Controls Test</Product>
     <Description>DataTools Utility Library</Description>
     <Copyright>Copyright (C) 2023 Nathaniel Moschkin</Copyright>
     <RepositoryUrl>https://www.github.com/nmoschkin/DataTools</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PreviousVersion>8.0.0.1022</PreviousVersion>
+    <PreviousVersion>8.0.0.1036</PreviousVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TouchTracking.Forms" Version="1.1.0" />


### PR DESCRIPTION
Multi-Targeting Work
Documentation Changes
Integrating newer version of TextTools.cs
Added assisted binary search function BinarySearch.Search to DataTools Essentials.

Please note, you still need [post-build-tool](https://github.com/nmoschkin/post-build-tool) to work.